### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use official Python base image
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y nmap && \
+    apt-get clean
+
+# Set working directory
+WORKDIR /app
+
+# Copy all files into the container
+COPY . /app
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt.txt
+
+# Set default command for CI mode
+CMD ["python", "main.py", "--ci"]


### PR DESCRIPTION
This pull request introduces a Dockerfile to enable containerized deployment of the vulnerability scanner project.

Key updates:
- Adds a Dockerfile that installs system dependencies (including nmap) and project requirements
- Sets up the container to run the scanner in CLI mode (`--ci`) by default
- Prepares the project for local Docker use, Jenkins, or cloud-based deployments (e.g., AWS ECS)

This change lays the groundwork for further automation and platform-independent deployments.

No application logic is changed in this commit.